### PR TITLE
Feat: added custom context to request

### DIFF
--- a/client.go
+++ b/client.go
@@ -150,6 +150,10 @@ func (client Client) Do(request Request) (*Response, error) {
 		return nil, &Error{Err: err}
 	}
 
+	if request.Context != nil {
+		req.WithContext(request.Context)
+	}
+
 	if request.ShowDebug {
 		dump, err := httputil.DumpRequest(req, true)
 		if err != nil {

--- a/goreq.go
+++ b/goreq.go
@@ -14,6 +14,8 @@ import (
 	"net/url"
 	"reflect"
 	"strings"
+
+	"golang.org/x/net/context"
 )
 
 type itimeout interface {
@@ -37,6 +39,7 @@ type Request struct {
 	BasicAuthPassword string
 	ShowDebug         bool
 	OnBeforeRequest   func(goreq *Request, httpreq *http.Request)
+	Context           context.Context
 }
 
 type compression struct {


### PR DESCRIPTION
Added field Context in Request so it can be a custom context.

Using the `context.WithCancel` the request can be cancelled, solving the issues #7 and #3 