### PR TITLE
fix: :bug: valueOrDefault() pass by ref and some idiomatic improvements 

### DIFF
--- a/client.go
+++ b/client.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/imdario/mergo"
+	"dario.cat/mergo"
 )
 
 const (
@@ -22,7 +22,7 @@ const (
 	defaultClientTLS         = false
 )
 
-//Options for create a client.
+// Options for create a client.
 type Options struct {
 	Timeout             time.Duration
 	Insecure            bool
@@ -33,7 +33,7 @@ type Options struct {
 	MaxIdleConnsPerHost int
 }
 
-//AddProxyConnectHeader add an Proxy connect header.
+// AddProxyConnectHeader add an Proxy connect header.
 func (options Options) AddProxyConnectHeader(name string, value string) {
 	if options.ProxyConnectHeaders == nil {
 		options.ProxyConnectHeaders = make(http.Header)
@@ -41,7 +41,7 @@ func (options Options) AddProxyConnectHeader(name string, value string) {
 	options.ProxyConnectHeaders.Add(name, value)
 }
 
-//Client for do request in http.
+// Client for do request in http.
 type Client struct {
 	*http.Client
 }
@@ -137,8 +137,8 @@ func (client Client) setConnectTimeout(timeout time.Duration) {
 	}
 }
 
-//Do sends an HTTP request and returns an HTTP response,
-//following policy (such as redirects, cookies, auth) as configured on the client.
+// Do sends an HTTP request and returns an HTTP response,
+// following policy (such as redirects, cookies, auth) as configured on the client.
 func (client Client) Do(request Request) (*Response, error) {
 
 	if erro := client.check(); erro != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -289,19 +289,19 @@ func TestRedirectPolicy(t *testing.T) {
 		g.Before(func() {
 			ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method == "GET" && r.URL.Path == "/redirect_test/301" {
-					http.Redirect(w, r, "/redirect_test/302", 301)
+					http.Redirect(w, r, "/redirect_test/302", http.StatusMovedPermanently)
 				}
 				if r.Method == "GET" && r.URL.Path == "/redirect_test/302" {
-					http.Redirect(w, r, "/redirect_test/303", 302)
+					http.Redirect(w, r, "/redirect_test/303", http.StatusFound)
 				}
 				if r.Method == "GET" && r.URL.Path == "/redirect_test/303" {
-					http.Redirect(w, r, "/redirect_test/307", 303)
+					http.Redirect(w, r, "/redirect_test/307", http.StatusSeeOther)
 				}
 				if r.Method == "GET" && r.URL.Path == "/redirect_test/307" {
-					http.Redirect(w, r, "/getquery", 307)
+					http.Redirect(w, r, "/getquery", http.StatusTemporaryRedirect)
 				}
 				if r.Method == "GET" && r.URL.Path == "/redirect_test/destination" {
-					http.Redirect(w, r, ts.URL+"/destination", 301)
+					http.Redirect(w, r, ts.URL+"/destination", http.StatusMovedPermanently)
 				}
 				if r.Method == "GET" && r.URL.Path == "/destination" {
 					w.WriteHeader(200)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/OmarMesqq/goreq
+module goreq
 
 go 1.21.2
 
@@ -6,7 +6,7 @@ require (
 	github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf
 	github.com/onsi/gomega v1.28.0
 )
-
+replace github.com/globocom/goreq => github.com/OmarMesqq/goreq v0.0.0-20231013164015-d857b9949aab
 require (
 	dario.cat/mergo v1.0.0
 	github.com/google/go-cmp v0.5.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module goreq
+module github.com/OmarMesqq/goreq
 
 go 1.21.2
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,16 @@
+module goreq
+
+go 1.21.2
+
+require (
+	github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf
+	github.com/onsi/gomega v1.28.0
+)
+
+require (
+	dario.cat/mergo v1.0.0
+	github.com/google/go-cmp v0.5.9 // indirect
+	golang.org/x/net v0.14.0 // indirect
+	golang.org/x/text v0.12.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/OmarMesqq/goreq
+module goreq
 
 go 1.21.2
 
@@ -6,7 +6,7 @@ require (
 	github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf
 	github.com/onsi/gomega v1.28.0
 )
-replace github.com/globocom/goreq => github.com/OmarMesqq/goreq v0.0.0-20231013164015-d857b9949aab
+
 require (
 	dario.cat/mergo v1.0.0
 	github.com/google/go-cmp v0.5.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,15 @@
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
+github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf h1:NrF81UtW8gG2LBGkXFQFqlfNnvMt9WdB46sfdJY4oqc=
+github.com/franela/goblin v0.0.0-20211003143422-0a4f594942bf/go.mod h1:VzmDKDJVZI3aJmnRI9VjAn9nJ8qPPsN1fqzr9dqInIo=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/onsi/gomega v1.28.0 h1:i2rg/p9n/UqIDAMFUJ6qIUUMcsqOuUHgbpbu235Vr1c=
+github.com/onsi/gomega v1.28.0/go.mod h1:A1H2JE76sI14WIP57LMKj7FVfCHx3g3BcZVjJG8bjX8=
+golang.org/x/net v0.14.0 h1:BONx9s002vGdD9umnlX1Po8vOZmrgH34qlHcD1MfK14=
+golang.org/x/net v0.14.0/go.mod h1:PpSgVXXLK0OxS0F31C1/tv6XNguvCrnXIDrFMspZIUI=
+golang.org/x/text v0.12.0 h1:k+n5B8goJNdU7hSvEtMUz3d1Q6D/XW4COJSJR6fN0mc=
+golang.org/x/text v0.12.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/goreq.go
+++ b/goreq.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -20,7 +19,7 @@ type itimeout interface {
 	Timeout() bool
 }
 
-//Request represents an HTTP request to be sent by a client.
+// Request represents an HTTP request to be sent by a client.
 type Request struct {
 	headers           []headerTuple
 	cookies           []*http.Cookie
@@ -45,7 +44,7 @@ type compression struct {
 	ContentEncoding string
 }
 
-//Response represents the response from an HTTP request.
+// Response represents the response from an HTTP request.
 type Response struct {
 	*http.Response
 	Uri  string
@@ -96,7 +95,7 @@ func (b *Body) FromJsonTo(o interface{}) error {
 }
 
 func (b *Body) ToString() (string, error) {
-	body, err := ioutil.ReadAll(b)
+	body, err := io.ReadAll(b)
 	if err != nil {
 		return "", err
 	}
@@ -217,7 +216,7 @@ func prepareRequestBody(b interface{}) (io.Reader, error) {
 	}
 }
 
-//AddHeader add header in request.
+// AddHeader add header in request.
 func (request *Request) AddHeader(name string, value string) {
 	if request.headers == nil {
 		request.headers = []headerTuple{}
@@ -225,7 +224,7 @@ func (request *Request) AddHeader(name string, value string) {
 	request.headers = append(request.headers, headerTuple{name: name, value: value})
 }
 
-//AddCookie add cookie in request.
+// AddCookie add cookie in request.
 func (request *Request) AddCookie(cookie *http.Cookie) {
 	request.cookies = append(request.cookies, cookie)
 }
@@ -242,7 +241,7 @@ func (r Request) addHeaders(headersMap http.Header) {
 	}
 }
 
-//NewRequest returns a new Request given a method, URL, and optional body.
+// NewRequest returns a new Request given a method, URL, and optional body.
 func (r Request) NewRequest() (*http.Request, error) {
 
 	r.valueOrDefault()

--- a/goreq.go
+++ b/goreq.go
@@ -307,7 +307,7 @@ func (r Request) NewRequest() (*http.Request, error) {
 }
 
 // Return value if nonempty, def otherwise.
-func (request Request) valueOrDefault() {
+func (request *Request) valueOrDefault() {
 	if request.Method == "" {
 		request.Method = "GET"
 	}

--- a/goreq_test.go
+++ b/goreq_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"net"
 	"net/http"
@@ -58,7 +57,7 @@ func TestRequest(t *testing.T) {
 					}
 					if r.Method == "GET" && r.URL.Path == "/getquery" {
 						w.WriteHeader(200)
-						fmt.Fprint(w, fmt.Sprintf("%v", r.URL))
+						fmt.Fprintf(w, "%v", r.URL)
 					}
 					if r.Method == "GET" && r.URL.Path == "/getbody" {
 						w.WriteHeader(200)
@@ -71,7 +70,7 @@ func TestRequest(t *testing.T) {
 					}
 					if r.Method == "POST" && r.URL.Path == "/getquery" {
 						w.WriteHeader(200)
-						fmt.Fprint(w, fmt.Sprintf("%v", r.URL))
+						fmt.Fprintf(w, "%v", r.URL)
 					}
 					if r.Method == "PUT" && r.URL.Path == "/foo/123" {
 						w.WriteHeader(200)
@@ -132,7 +131,7 @@ func TestRequest(t *testing.T) {
 						defer r.Body.Close()
 						gr, _ := gzip.NewReader(r.Body)
 						defer gr.Close()
-						b, _ := ioutil.ReadAll(gr)
+						b, _ := io.ReadAll(gr)
 						w.WriteHeader(201)
 						w.Write(b)
 					}
@@ -140,7 +139,7 @@ func TestRequest(t *testing.T) {
 						defer r.Body.Close()
 						gr, _ := zlib.NewReader(r.Body)
 						defer gr.Close()
-						b, _ := ioutil.ReadAll(gr)
+						b, _ := io.ReadAll(gr)
 						w.WriteHeader(201)
 						w.Write(b)
 					}
@@ -306,7 +305,7 @@ func TestRequest(t *testing.T) {
 					}
 					res, err := client.Do(request)
 
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 
 					Expect(err).Should(BeNil())
 					Expect(res.Body.compressedReader).ShouldNot(BeNil())
@@ -326,21 +325,21 @@ func TestRequest(t *testing.T) {
 
 					Expect(err).Should(BeNil())
 
-					_, e := ioutil.ReadAll(res.Body.reader)
+					_, e := io.ReadAll(res.Body.reader)
 					Expect(e).Should(BeNil())
-					_, e = ioutil.ReadAll(res.Body.compressedReader)
+					_, e = io.ReadAll(res.Body.compressedReader)
 					Expect(e).Should(BeNil())
 
-					_, e = ioutil.ReadAll(res.Body.reader)
+					_, e = io.ReadAll(res.Body.reader)
 					//when reading body again it doesnt error
 					Expect(e).Should(BeNil())
 
 					res.Body.Close()
-					_, e = ioutil.ReadAll(res.Body.reader)
+					_, e = io.ReadAll(res.Body.reader)
 					//error because body is already closed
 					Expect(e).ShouldNot(BeNil())
 
-					_, e = ioutil.ReadAll(res.Body.compressedReader)
+					_, e = io.ReadAll(res.Body.compressedReader)
 					//compressedReaders dont error on reading when closed
 					Expect(e).Should(BeNil())
 				})
@@ -353,7 +352,7 @@ func TestRequest(t *testing.T) {
 					}
 					res, err := client.Do(request)
 
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 
 					Expect(err).Should(BeNil())
 					Expect(string(b)).ShouldNot(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
@@ -367,7 +366,7 @@ func TestRequest(t *testing.T) {
 					}
 					res, err := client.Do(request)
 
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 
 					Expect(err).Should(BeNil())
 					Expect(string(b)).Should(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
@@ -381,7 +380,7 @@ func TestRequest(t *testing.T) {
 					}
 					res, err := client.Do(request)
 
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 
 					Expect(err).Should(BeNil())
 					Expect(string(b)).ShouldNot(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
@@ -395,7 +394,7 @@ func TestRequest(t *testing.T) {
 					}
 					res, err := client.Do(request)
 
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 
 					Expect(err).Should(BeNil())
 					Expect(string(b)).Should(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
@@ -409,7 +408,7 @@ func TestRequest(t *testing.T) {
 					}
 					res, err := client.Do(request)
 
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 
 					Expect(err).Should(BeNil())
 					Expect(string(b)).ShouldNot(Equal("{\"foo\":\"bar\",\"fuu\":\"baz\"}"))
@@ -657,7 +656,7 @@ func TestRequest(t *testing.T) {
 					res, err := client.Do(request)
 
 					Expect(err).Should(BeNil())
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 					Expect(string(b)).Should(Equal(`{"foo":"bar"}`))
 					Expect(res.StatusCode).Should(Equal(201))
 				})
@@ -674,7 +673,7 @@ func TestRequest(t *testing.T) {
 					res, err := client.Do(request)
 
 					Expect(err).Should(BeNil())
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 					Expect(string(b)).Should(Equal(`{"foo":"bar"}`))
 					Expect(res.StatusCode).Should(Equal(201))
 				})
@@ -691,7 +690,7 @@ func TestRequest(t *testing.T) {
 					res, err := client.Do(request)
 
 					Expect(err).Should(BeNil())
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 					Expect(string(b)).Should(Equal(`{"foo":"bar"}`))
 					Expect(res.StatusCode).Should(Equal(201))
 				})
@@ -708,7 +707,7 @@ func TestRequest(t *testing.T) {
 					res, err := client.Do(request)
 
 					Expect(err).Should(BeNil())
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 					Expect(string(b)).ShouldNot(Equal(`{"foo":"bar"}`))
 					Expect(res.StatusCode).Should(Equal(201))
 				})
@@ -725,7 +724,7 @@ func TestRequest(t *testing.T) {
 					res, err := client.Do(request)
 
 					Expect(err).Should(BeNil())
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 					Expect(string(b)).ShouldNot(Equal(`{"foo":"bar"}`))
 					Expect(res.StatusCode).Should(Equal(201))
 				})
@@ -742,7 +741,7 @@ func TestRequest(t *testing.T) {
 					res, err := client.Do(request)
 
 					Expect(err).Should(BeNil())
-					b, _ := ioutil.ReadAll(res.Body)
+					b, _ := io.ReadAll(res.Body)
 					Expect(string(b)).ShouldNot(Equal(`{"foo":"bar"}`))
 					Expect(res.StatusCode).Should(Equal(201))
 				})
@@ -854,7 +853,7 @@ func TestRequest(t *testing.T) {
 					}
 					res, _ := client.Do(request)
 
-					body, _ := ioutil.ReadAll(res.Body)
+					body, _ := io.ReadAll(res.Body)
 					Expect(string(body)).Should(Equal("foo bar"))
 				})
 
@@ -963,7 +962,7 @@ func TestRequest(t *testing.T) {
 
 			g.It("Should not create a body by default", func() {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					b, _ := ioutil.ReadAll(r.Body)
+					b, _ := io.ReadAll(r.Body)
 					Expect(b).Should(HaveLen(0))
 					w.WriteHeader(200)
 				}))
@@ -1094,7 +1093,7 @@ func TestRequest(t *testing.T) {
 						w.WriteHeader(200)
 						w.Write([]byte(""))
 					} else if r.Method == "GET" && r.URL.Path == "/redirect_test/301" {
-						http.Redirect(w, r, "/", 301)
+						http.Redirect(w, r, "/", http.StatusMovedPermanently)
 					}
 				}))
 


### PR DESCRIPTION
This PR doesn't address any of the open issues, instead, it fixes the function that checks the HTTP method, defaulting to `GET`. The bug was happening because the value was never changed: the copy wasn' t returned or a pointer wasn't passed. To address this, I propose we pass it as a pointer, which should be faster.


Also addressed some linter warnings that may render the project broken in the future.

The changes are listed below: 

- :arrow_up:   :Point the `mergo` dep to the author's new address `dario.cat/mergo`
- :recycle: :Use constants defined by the `http` STL instead of numerical literals (such as 303, 404, etc)
- :recycle: :Remove deprecated `ioutil` dep and use the already imported `io`
- :recycle: :Change the string formatting to a less verbose one 
- :construction: :Create `go.mod` for easier devtime setup 
- :bug:  : the function `valueOrDefault()` didn't do anything since its value was passed as a copy and never returned. Now it takes a pointer and actually changes the value.


@YasminTeles tagging you as reviewer :)  